### PR TITLE
Join pool fix

### DIFF
--- a/tools_mp/__init__.py
+++ b/tools_mp/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.2.0'
+__version__ = '0.3.0'
 
 
 from .processor import multiprocess

--- a/tools_mp/processor.py
+++ b/tools_mp/processor.py
@@ -20,26 +20,29 @@ def multiprocess(
         workers = multiprocessing.cpu_count()
 
     # Set up the pool with workers and kwargs
-    with multiprocessing.Pool(
-        workers,
-        **kwargs,
-    ) as pool:
-        tasks = ((function, x) for x in args)
-        if return_data:
-            data = []
-            if verbose :
-                for x in tqdm.tqdm(pool.imap(_worker, tasks), total=len(args)):
-                    data.append(x)
-            else:
-                for x in pool.imap(_worker, tasks):
-                    data.append(x)
+    pool = multiprocessing.Pool( workers, **kwargs )
+
+    # Run the pool
+    tasks = ((function, x) for x in args)
+    if return_data:
+        data = []
+        if verbose :
+            for x in tqdm.tqdm(pool.imap(_worker, tasks), total=len(args)):
+                data.append(x)
         else:
-            data = None
-            if verbose:
-                for x in tqdm.tqdm(pool.imap(_worker, tasks), total=len(args)):
-                    pass
-            else:
-                pool.imap(_worker, tasks)
+            for x in pool.imap(_worker, tasks):
+                data.append(x)
+    else:
+        data = None
+        if verbose:
+            for x in tqdm.tqdm(pool.imap(_worker, tasks), total=len(args)):
+                pass
+        else:
+            pool.imap(_worker, tasks)
+            
+    # Clean up
+    pool.close()
+    pool.join()
     return data
 
 def process(


### PR DESCRIPTION
Previous way to end the multiprocessing pool (via "with pool ...") terminates the processes rather than end them gracefully via close()+join(), which can lead to issues in certain environments.
This change re-introduces the ending via close()+join().